### PR TITLE
Fixes src and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ same networks, the full set of names does not resolve.
 ``` bash
 $ sudo -i
 mkdir -p /etc/coredns-zt
-echo "API_TOKEN" > /etc/coredns-zt/api-token
+echo "ZT_API_TOKEN=secretoken" > /etc/coredns-zt/api-token
 chmod 0600 /etc/coredns-zt/api-token
 ```
 

--- a/default.nix
+++ b/default.nix
@@ -1,12 +1,22 @@
-{ stdenv
+{ stdenv, fetchFromGitHub
 , jq, zerotierone, curl
 , utillinux
 }:
-
+let
+  gitignoreSrc = fetchFromGitHub {
+    owner = "hercules-ci";
+    repo = "gitignore";
+    # put the latest commit sha of gitignore Nix library here:
+    rev = "f9e996052b5af4032fe6150bba4a6fe4f7b9d698";
+    # use what nix suggests in the mismatch message here:
+    sha256 = "sha256:0jrh5ghisaqdd0vldbywags20m2cxpkbbk5jjjmwaw0gr8nhsafv";
+  };
+  inherit (import gitignoreSrc {}) gitignoreSource;
+in
 stdenv.mkDerivation rec {
   pname = "coredns-zt";
   version = "0.0";
-  src = builtins.fetchGit ./.;
+  src = gitignoreSource ./.;
 
   patchPhase = ''
     substituteInPlace ./zt2hosts \


### PR DESCRIPTION
Hey @thoughtpolice when I try to use this module in my `configuration.nix` like this:

```
  ztdns =  (import <nixpkgs> {}).fetchFromGitHub {
      owner =  "thoughtpolice";
      repo = "nixos-zerotier-dns";
      rev = "....";
      sha256 = "sha256:....";
    };

....

  imports =
    [ # Include the results of the hardware scan.
      ./hardware-configuration.nix
      "${ztdns}/module.nix"
    ];
```
I saw issues with `builtins.fetchGit ./.;` erroring with "not a git repository" or something along those lines. I tried using the other variants of functions for fetching from git but it had all sorts of other issues. I also tried vendoring in the repo within my nixos-configs repo but that didn't work either. The only other option was to clone this repo somewhere and point to it from my configuration.nix but then my nixos-configs wouldn't be self sufficient (ie. it would rely on some repo being cloned somewhere on my disk). 
I figured the only reason this was here was because you didn't want to include files that were in `.gitignore` so I worked around it with `gitignoreSource`. Perhaps you would want to add more files to .gitignore now that this is in place?

The other fix is just the naming of the token env var in the README. 